### PR TITLE
Add Rainbow, MetaMask, and Valora wallet support

### DIFF
--- a/packages/react-app/providers/AppProvider.tsx
+++ b/packages/react-app/providers/AppProvider.tsx
@@ -11,13 +11,13 @@ import { WagmiProvider, createConfig, http } from 'wagmi';
 import { celo, celoAlfajores } from 'wagmi/chains';
 
 import Layout from '../components/Layout';
-import { injectedWallet } from '@rainbow-me/rainbowkit/wallets';
+import { injectedWallet, rainbowWallet, metaMaskWallet, valoraWallet } from '@rainbow-me/rainbowkit/wallets';
 
 const connectors = connectorsForWallets(
   [
     {
       groupName: 'Recommended',
-      wallets: [injectedWallet],
+      wallets: [injectedWallet, rainbowWallet, metaMaskWallet, valoraWallet],
     },
   ],
   {


### PR DESCRIPTION
# Added support for additional wallet providers

This PR adds support for three new wallet providers:
- Rainbow Wallet
- MetaMask Wallet
- Valora Wallet

These additional wallet options expand user choice for connecting to our dApp and improve accessibility across different user preferences. All new wallets have been tested for connection compatibility.

## Testing
- Verified connection flow with each new wallet
- Tested transaction signing functionality
- Confirmed wallet disconnection works properly

## Related Issues
Closes [#4](https://github.com/Olisehgenesis/sovereign-seas/issues/4)